### PR TITLE
Make LDAP query attributes configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO ?= ghcr.io/tinyzimmer
 NAME = kvdi
-VERSION ?= v0.1.1
+VERSION ?= v0.1.2
 
 # includes
 -include hack/Makevars.mk

--- a/deploy/charts/kvdi/crds/kvdi.io_vdiclusters_crd.yaml
+++ b/deploy/charts/kvdi/crds/kvdi.io_vdiclusters_crd.yaml
@@ -136,6 +136,13 @@ spec:
                           In default configurations this is `kvdi-app-secrets`. Defaults
                           to `ldap-userdn`.
                         type: string
+                      insecureSkipStatusCheck:
+                        description: Disable checking if an account is active when
+                          authenticating users with LDAP. Defaults to `false`. This
+                          may be required for LDAP providers that don't provide an
+                          `accountStatus` and instead just don't allow binding to
+                          begin with.
+                        type: boolean
                       tlsCACert:
                         description: The base64 encoded CA certificate to use when
                           verifying the TLS certificate of the LDAP server.
@@ -147,9 +154,25 @@ spec:
                       url:
                         description: The URL to the LDAP server.
                         type: string
+                      userGroupsAttribute:
+                        description: The user attribute use to lookup group membership
+                          in LDAP. Defaults to `memberOf`.
+                        type: string
+                      userIDAttribute:
+                        description: The user ID attribute to use when looking up
+                          a provided username. Defaults to `uid`. This value may be
+                          different depending on the LDAP provider. For example, in
+                          an Active Directory environment you may want to set this
+                          value to `sAMAccountName`.
+                        type: string
                       userSearchBase:
                         description: The base scope to search for users in. Default
                           is to search the entire directory.
+                        type: string
+                      userStatusAttribute:
+                        description: The user attribute to use when querying if an
+                          account is active. Defaults to `accountStatus`. To disable
+                          this check entirely, see insecureSkipStatusCheck.
                         type: string
                     type: object
                   localAuth:

--- a/deploy/examples/example-ldap-helm-values.yaml
+++ b/deploy/examples/example-ldap-helm-values.yaml
@@ -7,3 +7,4 @@ vdi:
         bindPasswordSecretKey: "ldap-password"
         adminGroups: ["cn=kvdi-admins,ou=groups,dc=kvdi,dc=io"]
         userSearchBase: "ou=users,dc=kvdi,dc=io"
+        userIDAttribute: mail

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -1,5 +1,4 @@
-kVDI CRD Reference
-------------------
+## kVDI CRD Reference
 
 ### Packages:
 
@@ -32,8 +31,7 @@ Types
 -   [VDIRole](#VDIRole)
 -   [VaultConfig](#VaultConfig)
 
-kvdi.io/v1alpha1
-----------------
+## kvdi.io/v1alpha1
 
 Package v1alpha1 contains API Schema definitions for the kvdi v1alpha1
 API group
@@ -479,6 +477,22 @@ authentication backend.
 <td><code>userSearchBase</code> <em>string</em></td>
 <td><p>The base scope to search for users in. Default is to search the entire directory.</p></td>
 </tr>
+<tr class="odd">
+<td><code>userIDAttribute</code> <em>string</em></td>
+<td><p>The user ID attribute to use when looking up a provided username. Defaults to <code>uid</code>. This value may be different depending on the LDAP provider. For example, in an Active Directory environment you may want to set this value to <code>sAMAccountName</code>.</p></td>
+</tr>
+<tr class="even">
+<td><code>userGroupsAttribute</code> <em>string</em></td>
+<td><p>The user attribute use to lookup group membership in LDAP. Defaults to <code>memberOf</code>.</p></td>
+</tr>
+<tr class="odd">
+<td><code>userStatusAttribute</code> <em>string</em></td>
+<td><p>The user attribute to use when querying if an account is active. Defaults to <code>accountStatus</code>. To disable this check entirely, see insecureSkipStatusCheck.</p></td>
+</tr>
+<tr class="even">
+<td><code>insecureSkipStatusCheck</code> <em>bool</em></td>
+<td><p>Disable checking if an account is active when authenticating users with LDAP. Defaults to <code>false</code>. This may be required for LDAP providers that don’t provide an <code>accountStatus</code> and instead just don’t allow binding to begin with.</p></td>
+</tr>
 </tbody>
 </table>
 
@@ -869,4 +883,4 @@ server.
 
 ------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `eade2e6`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `4ba8b7e`.*

--- a/doc/metav1.md
+++ b/doc/metav1.md
@@ -1,5 +1,4 @@
-kVDI CRD Reference
-------------------
+## kVDI CRD Reference
 
 ### Packages:
 
@@ -33,8 +32,7 @@ Types
 -   [VDIUserRole](#VDIUserRole)
 -   [Verb](#Verb)
 
-kvdi.io/v1
-----------
+## kvdi.io/v1
 
 Package v1 contains API Schema definitions for the meta v1 API group
 
@@ -619,4 +617,4 @@ Verb represents an API action
 
 ------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `eade2e6`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `4ba8b7e`.*

--- a/hack/glauth.yaml
+++ b/hack/glauth.yaml
@@ -54,6 +54,7 @@ data:
     #   to create a passSHA256:   echo -n "mysecret" | openssl dgst -sha256
     [[users]]
       name = "kvdi-admin"
+      mail = "admin@kvdi.com"
       unixid = 5001
       primarygroup = 5500
       otherGroups = [5501,5502]
@@ -75,6 +76,7 @@ data:
     [[users]]
       name = "otpuser"
       unixid = 5003
+      mail = "otp@kvdi.com"
       primarygroup = 5500
       otherGroups = [5502]
       passsha256 = "652c7dc687d98c9889304ed2e408c74b611e86a40caa51c4b43f1dd5913c5cd0" # mysecret

--- a/pkg/apis/kvdi/v1alpha1/auth_ldap_util.go
+++ b/pkg/apis/kvdi/v1alpha1/auth_ldap_util.go
@@ -91,3 +91,42 @@ func (c *VDICluster) GetLDAPAdminGroups() []string {
 	}
 	return []string{}
 }
+
+// GetLDAPUserIDAttribute returns the user attribute to use when querying user IDs.
+func (c *VDICluster) GetLDAPUserIDAttribute() string {
+	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
+		if c.Spec.Auth.LDAPAuth.UserIDAttribute != "" {
+			return c.Spec.Auth.LDAPAuth.UserIDAttribute
+		}
+	}
+	return "uid"
+}
+
+// GetLDAPUserGroupsAttribute returns the user attribute to use when querying user groups.
+func (c *VDICluster) GetLDAPUserGroupsAttribute() string {
+	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
+		if c.Spec.Auth.LDAPAuth.UserGroupsAttribute != "" {
+			return c.Spec.Auth.LDAPAuth.UserGroupsAttribute
+		}
+	}
+	return "memberOf"
+}
+
+// GetLDAPUserStatusAttribute returns the user attribute to use when querying account status.
+func (c *VDICluster) GetLDAPUserStatusAttribute() string {
+	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
+		if c.Spec.Auth.LDAPAuth.UserStatusAttribute != "" {
+			return c.Spec.Auth.LDAPAuth.UserStatusAttribute
+		}
+	}
+	return "accountStatus"
+}
+
+// GetLDAPSkipUserStatusCheck returns if the account status check should be skipped when performing
+// user authentication.
+func (c *VDICluster) GetLDAPSkipUserStatusCheck() bool {
+	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
+		return c.Spec.Auth.LDAPAuth.InsecureSkipStatusCheck
+	}
+	return false
+}

--- a/pkg/apis/kvdi/v1alpha1/vdicluster_types.go
+++ b/pkg/apis/kvdi/v1alpha1/vdicluster_types.go
@@ -167,6 +167,19 @@ type LDAPConfig struct {
 	// The base scope to search for users in. Default is to search the entire
 	// directory.
 	UserSearchBase string `json:"userSearchBase,omitempty"`
+	// The user ID attribute to use when looking up a provided username. Defaults to `uid`.
+	// This value may be different depending on the LDAP provider. For example, in an Active Directory
+	// environment you may want to set this value to `sAMAccountName`.
+	UserIDAttribute string `json:"userIDAttribute,omitempty"`
+	// The user attribute use to lookup group membership in LDAP. Defaults to `memberOf`.
+	UserGroupsAttribute string `json:"userGroupsAttribute,omitempty"`
+	// The user attribute to use when querying if an account is active. Defaults to `accountStatus`.
+	// To disable this check entirely, see insecureSkipStatusCheck.
+	UserStatusAttribute string `json:"userStatusAttribute,omitempty"`
+	// Disable checking if an account is active when authenticating users with LDAP. Defaults to `false`.
+	// This may be required for LDAP providers that don't provide an `accountStatus` and instead just don't
+	// allow binding to begin with.
+	InsecureSkipStatusCheck bool `json:"insecureSkipStatusCheck,omitempty"`
 }
 
 // IsUndefined returns true if the given LDAPConfig object is not actually configured.

--- a/pkg/auth/providers/ldap/provider.go
+++ b/pkg/auth/providers/ldap/provider.go
@@ -14,11 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const userFilter = "(uid=%s)"
-const groupUsersFilter = "(memberOf=%s)"
-
-var userAttrs = []string{"cn", "dn", "uid", "memberOf", "accountStatus"}
-
 // AuthProvider implements an auth provider that uses an LDAP server as the
 // authentication backend. Access to groups in LDAP is supplied through annotations
 // on VDIRoles.

--- a/pkg/auth/providers/ldap/util.go
+++ b/pkg/auth/providers/ldap/util.go
@@ -1,8 +1,28 @@
 package ldap
 
+import (
+	"fmt"
+)
+
 func (a *AuthProvider) getUserBase() string {
 	if base := a.cluster.GetLDAPSearchBase(); base != "" {
 		return base
 	}
 	return a.baseDN
+}
+
+func (a *AuthProvider) userAttrs() []string {
+	attrs := []string{"cn", "dn", a.cluster.GetLDAPUserIDAttribute(), a.cluster.GetLDAPUserGroupsAttribute()}
+	if !a.cluster.GetLDAPSkipUserStatusCheck() {
+		attrs = append(attrs, a.cluster.GetLDAPUserStatusAttribute())
+	}
+	return attrs
+}
+
+func (a *AuthProvider) userFilter() string {
+	return fmt.Sprintf("(%s=%%s)", a.cluster.GetLDAPUserIDAttribute())
+}
+
+func (a *AuthProvider) groupUsersFilter() string {
+	return fmt.Sprintf("(%s=%%s)", a.cluster.GetLDAPUserGroupsAttribute())
 }


### PR DESCRIPTION
Adds the following attributes to `ldapConfig`:

 - `userIDAttribute` - The user attribute to use for the user ID, defaults to `uid`. 
 - `userGroupsAttribute` - The user attribute to use to check the list of groups a user is a member of. Defaults to `memberOf`.
 - `userStatusAttribute` - The attribute to use to query if an account is active. Defaults to `accountStatus`.
 - `insecureSkipStatusCheck` - Disable checking if a user account is active during the authentication flow.