### PR TITLE
Remove the check for if a user is disabled before attempting to bind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO ?= ghcr.io/tinyzimmer
 NAME = kvdi
-VERSION ?= v0.1.2
+VERSION ?= v0.1.3
 
 # includes
 -include hack/Makevars.mk

--- a/deploy/charts/kvdi/crds/kvdi.io_vdiclusters_crd.yaml
+++ b/deploy/charts/kvdi/crds/kvdi.io_vdiclusters_crd.yaml
@@ -136,13 +136,6 @@ spec:
                           In default configurations this is `kvdi-app-secrets`. Defaults
                           to `ldap-userdn`.
                         type: string
-                      insecureSkipStatusCheck:
-                        description: Disable checking if an account is active when
-                          authenticating users with LDAP. Defaults to `false`. This
-                          may be required for LDAP providers that don't provide an
-                          `accountStatus` and instead just don't allow binding to
-                          begin with.
-                        type: boolean
                       tlsCACert:
                         description: The base64 encoded CA certificate to use when
                           verifying the TLS certificate of the LDAP server.
@@ -168,11 +161,6 @@ spec:
                       userSearchBase:
                         description: The base scope to search for users in. Default
                           is to search the entire directory.
-                        type: string
-                      userStatusAttribute:
-                        description: The user attribute to use when querying if an
-                          account is active. Defaults to `accountStatus`. To disable
-                          this check entirely, see insecureSkipStatusCheck.
                         type: string
                     type: object
                   localAuth:

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -485,14 +485,6 @@ authentication backend.
 <td><code>userGroupsAttribute</code> <em>string</em></td>
 <td><p>The user attribute use to lookup group membership in LDAP. Defaults to <code>memberOf</code>.</p></td>
 </tr>
-<tr class="odd">
-<td><code>userStatusAttribute</code> <em>string</em></td>
-<td><p>The user attribute to use when querying if an account is active. Defaults to <code>accountStatus</code>. To disable this check entirely, see insecureSkipStatusCheck.</p></td>
-</tr>
-<tr class="even">
-<td><code>insecureSkipStatusCheck</code> <em>bool</em></td>
-<td><p>Disable checking if an account is active when authenticating users with LDAP. Defaults to <code>false</code>. This may be required for LDAP providers that don’t provide an <code>accountStatus</code> and instead just don’t allow binding to begin with.</p></td>
-</tr>
 </tbody>
 </table>
 
@@ -883,4 +875,4 @@ server.
 
 ------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `27fd1ad`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `d224229`.*

--- a/doc/metav1.md
+++ b/doc/metav1.md
@@ -617,4 +617,4 @@ Verb represents an API action
 
 ------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `27fd1ad`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `d224229`.*

--- a/pkg/apis/kvdi/v1alpha1/auth_ldap_util.go
+++ b/pkg/apis/kvdi/v1alpha1/auth_ldap_util.go
@@ -111,22 +111,3 @@ func (c *VDICluster) GetLDAPUserGroupsAttribute() string {
 	}
 	return "memberOf"
 }
-
-// GetLDAPUserStatusAttribute returns the user attribute to use when querying account status.
-func (c *VDICluster) GetLDAPUserStatusAttribute() string {
-	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
-		if c.Spec.Auth.LDAPAuth.UserStatusAttribute != "" {
-			return c.Spec.Auth.LDAPAuth.UserStatusAttribute
-		}
-	}
-	return "accountStatus"
-}
-
-// GetLDAPSkipUserStatusCheck returns if the account status check should be skipped when performing
-// user authentication.
-func (c *VDICluster) GetLDAPSkipUserStatusCheck() bool {
-	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
-		return c.Spec.Auth.LDAPAuth.InsecureSkipStatusCheck
-	}
-	return false
-}

--- a/pkg/apis/kvdi/v1alpha1/vdicluster_types.go
+++ b/pkg/apis/kvdi/v1alpha1/vdicluster_types.go
@@ -173,13 +173,6 @@ type LDAPConfig struct {
 	UserIDAttribute string `json:"userIDAttribute,omitempty"`
 	// The user attribute use to lookup group membership in LDAP. Defaults to `memberOf`.
 	UserGroupsAttribute string `json:"userGroupsAttribute,omitempty"`
-	// The user attribute to use when querying if an account is active. Defaults to `accountStatus`.
-	// To disable this check entirely, see insecureSkipStatusCheck.
-	UserStatusAttribute string `json:"userStatusAttribute,omitempty"`
-	// Disable checking if an account is active when authenticating users with LDAP. Defaults to `false`.
-	// This may be required for LDAP providers that don't provide an `accountStatus` and instead just don't
-	// allow binding to begin with.
-	InsecureSkipStatusCheck bool `json:"insecureSkipStatusCheck,omitempty"`
 }
 
 // IsUndefined returns true if the given LDAPConfig object is not actually configured.

--- a/pkg/auth/providers/ldap/authenticate.go
+++ b/pkg/auth/providers/ldap/authenticate.go
@@ -50,12 +50,6 @@ func (a *AuthProvider) Authenticate(req *v1.LoginRequest) (*v1.AuthResult, error
 
 	user := sr.Entries[0]
 
-	if !a.cluster.GetLDAPSkipUserStatusCheck() {
-		if strings.ToLower(user.GetAttributeValue(a.cluster.GetLDAPUserStatusAttribute())) != "active" {
-			return nil, fmt.Errorf("User account %s is disabled", user.GetAttributeValue(a.cluster.GetLDAPUserIDAttribute()))
-		}
-	}
-
 	// perform a bind to check the credentials
 	if err := conn.Bind(user.DN, req.Password); err != nil {
 		return nil, err

--- a/pkg/auth/providers/ldap/util.go
+++ b/pkg/auth/providers/ldap/util.go
@@ -12,11 +12,7 @@ func (a *AuthProvider) getUserBase() string {
 }
 
 func (a *AuthProvider) userAttrs() []string {
-	attrs := []string{"cn", "dn", a.cluster.GetLDAPUserIDAttribute(), a.cluster.GetLDAPUserGroupsAttribute()}
-	if !a.cluster.GetLDAPSkipUserStatusCheck() {
-		attrs = append(attrs, a.cluster.GetLDAPUserStatusAttribute())
-	}
-	return attrs
+	return []string{"cn", "dn", a.cluster.GetLDAPUserIDAttribute(), a.cluster.GetLDAPUserGroupsAttribute()}
 }
 
 func (a *AuthProvider) userFilter() string {


### PR DESCRIPTION
#10 

Removes the account status check entirely and the `insecureSkipStatusCheck` from the previous PR