### PR TITLE
Make LDAP status check opt-in

### DIFF
--- a/deploy/charts/kvdi/crds/kvdi.io_vdiclusters_crd.yaml
+++ b/deploy/charts/kvdi/crds/kvdi.io_vdiclusters_crd.yaml
@@ -136,12 +136,11 @@ spec:
                           In default configurations this is `kvdi-app-secrets`. Defaults
                           to `ldap-userdn`.
                         type: string
-                      insecureSkipStatusCheck:
-                        description: Disable checking if an account is active when
-                          authenticating users with LDAP. Defaults to `false`. This
-                          may be required for LDAP providers that don't provide an
-                          `accountStatus` and instead just don't allow binding to
-                          begin with.
+                      doStatusCheck:
+                        description: When set to true, the authentication provider
+                          will query the user's attributes for the `userStatusAttribute`
+                          and make sure it matches the value in `userStatusEnabledValue`
+                          before attemtping to bind.
                         type: boolean
                       tlsCACert:
                         description: The base64 encoded CA certificate to use when
@@ -171,8 +170,14 @@ spec:
                         type: string
                       userStatusAttribute:
                         description: The user attribute to use when querying if an
-                          account is active. Defaults to `accountStatus`. To disable
-                          this check entirely, see insecureSkipStatusCheck.
+                          account is active. Defaults to `accountStatus`. Only takes
+                          effect if `doStatusCheck` is `true`. A user is considered
+                          disabled when the attribute is both present and matches
+                          the value in `userStatusDisabledValue`.
+                        type: string
+                      userStatusDisabledValue:
+                        description: The value for the `userStatusAttribute` that
+                          signifies that the user is disabled. Defaults to `inactive`.
                         type: string
                     type: object
                   localAuth:

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -487,11 +487,15 @@ authentication backend.
 </tr>
 <tr class="odd">
 <td><code>userStatusAttribute</code> <em>string</em></td>
-<td><p>The user attribute to use when querying if an account is active. Defaults to <code>accountStatus</code>. To disable this check entirely, see insecureSkipStatusCheck.</p></td>
+<td><p>The user attribute to use when querying if an account is active. Defaults to <code>accountStatus</code>. Only takes effect if <code>doStatusCheck</code> is <code>true</code>. A user is considered disabled when the attribute is both present and matches the value in <code>userStatusDisabledValue</code>.</p></td>
 </tr>
 <tr class="even">
-<td><code>insecureSkipStatusCheck</code> <em>bool</em></td>
-<td><p>Disable checking if an account is active when authenticating users with LDAP. Defaults to <code>false</code>. This may be required for LDAP providers that don’t provide an <code>accountStatus</code> and instead just don’t allow binding to begin with.</p></td>
+<td><code>userStatusDisabledValue</code> <em>string</em></td>
+<td><p>The value for the <code>userStatusAttribute</code> that signifies that the user is disabled. Defaults to <code>inactive</code>.</p></td>
+</tr>
+<tr class="odd">
+<td><code>doStatusCheck</code> <em>bool</em></td>
+<td><p>When set to true, the authentication provider will query the user’s attributes for the <code>userStatusAttribute</code> and make sure it matches the value in <code>userStatusEnabledValue</code> before attemtping to bind.</p></td>
 </tr>
 </tbody>
 </table>
@@ -883,4 +887,4 @@ server.
 
 ------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `27fd1ad`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `c18c30a`.*

--- a/doc/metav1.md
+++ b/doc/metav1.md
@@ -617,4 +617,4 @@ Verb represents an API action
 
 ------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `27fd1ad`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `c18c30a`.*

--- a/hack/glauth.yaml
+++ b/hack/glauth.yaml
@@ -71,6 +71,7 @@ data:
       otherGroups = [5502]
       loginShell = "/bin/sh"
       passsha256 = "6478579e37aff45f013e14eeb30b3cc56c72ccdc310123bcdf53e0333e3f416a" # dogood
+      disabled = true
 
     # Test user showing 2 factor auth authentication
     [[users]]

--- a/pkg/apis/kvdi/v1alpha1/auth_ldap_util.go
+++ b/pkg/apis/kvdi/v1alpha1/auth_ldap_util.go
@@ -122,11 +122,21 @@ func (c *VDICluster) GetLDAPUserStatusAttribute() string {
 	return "accountStatus"
 }
 
-// GetLDAPSkipUserStatusCheck returns if the account status check should be skipped when performing
-// user authentication.
-func (c *VDICluster) GetLDAPSkipUserStatusCheck() bool {
+// GetLDAPUserStatusDisabledValue returns the value to match that means the user is disabled.
+func (c *VDICluster) GetLDAPUserStatusDisabledValue() string {
 	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
-		return c.Spec.Auth.LDAPAuth.InsecureSkipStatusCheck
+		if c.Spec.Auth.LDAPAuth.UserStatusDisabledValue != "" {
+			return c.Spec.Auth.LDAPAuth.UserStatusDisabledValue
+		}
+	}
+	return "inactive"
+}
+
+// GetLDAPDoUserStatusCheck returns if the account status check should be done when performing
+// user authentication.
+func (c *VDICluster) GetLDAPDoUserStatusCheck() bool {
+	if c.Spec.Auth != nil && c.Spec.Auth.LDAPAuth != nil {
+		return c.Spec.Auth.LDAPAuth.DoStatusCheck
 	}
 	return false
 }

--- a/pkg/apis/kvdi/v1alpha1/vdicluster_types.go
+++ b/pkg/apis/kvdi/v1alpha1/vdicluster_types.go
@@ -174,12 +174,14 @@ type LDAPConfig struct {
 	// The user attribute use to lookup group membership in LDAP. Defaults to `memberOf`.
 	UserGroupsAttribute string `json:"userGroupsAttribute,omitempty"`
 	// The user attribute to use when querying if an account is active. Defaults to `accountStatus`.
-	// To disable this check entirely, see insecureSkipStatusCheck.
+	// Only takes effect if `doStatusCheck` is `true`. A user is considered disabled when the attribute is
+	// both present and matches the value in `userStatusDisabledValue`.
 	UserStatusAttribute string `json:"userStatusAttribute,omitempty"`
-	// Disable checking if an account is active when authenticating users with LDAP. Defaults to `false`.
-	// This may be required for LDAP providers that don't provide an `accountStatus` and instead just don't
-	// allow binding to begin with.
-	InsecureSkipStatusCheck bool `json:"insecureSkipStatusCheck,omitempty"`
+	// The value for the `userStatusAttribute` that signifies that the user is disabled. Defaults to `inactive`.
+	UserStatusDisabledValue string `json:"userStatusDisabledValue,omitempty"`
+	// When set to true, the authentication provider will query the user's attributes for the `userStatusAttribute`
+	// and make sure it matches the value in `userStatusEnabledValue` before attemtping to bind.
+	DoStatusCheck bool `json:"doStatusCheck,omitempty"`
 }
 
 // IsUndefined returns true if the given LDAPConfig object is not actually configured.

--- a/pkg/auth/providers/ldap/authenticate.go
+++ b/pkg/auth/providers/ldap/authenticate.go
@@ -51,7 +51,7 @@ func (a *AuthProvider) Authenticate(req *v1.LoginRequest) (*v1.AuthResult, error
 	user := sr.Entries[0]
 
 	if a.cluster.GetLDAPDoUserStatusCheck() {
-		if strings.ToLower(user.GetAttributeValue(a.cluster.GetLDAPUserStatusAttribute())) == strings.ToLower(a.cluster.GetLDAPUserStatusDisabledValue()) {
+		if strings.EqualFold(user.GetAttributeValue(a.cluster.GetLDAPUserStatusAttribute()), a.cluster.GetLDAPUserStatusDisabledValue()) {
 			return nil, fmt.Errorf("User account %s is disabled", user.GetAttributeValue(a.cluster.GetLDAPUserIDAttribute()))
 		}
 	}

--- a/pkg/auth/providers/ldap/authenticate.go
+++ b/pkg/auth/providers/ldap/authenticate.go
@@ -50,8 +50,8 @@ func (a *AuthProvider) Authenticate(req *v1.LoginRequest) (*v1.AuthResult, error
 
 	user := sr.Entries[0]
 
-	if !a.cluster.GetLDAPSkipUserStatusCheck() {
-		if strings.ToLower(user.GetAttributeValue(a.cluster.GetLDAPUserStatusAttribute())) != "active" {
+	if a.cluster.GetLDAPDoUserStatusCheck() {
+		if strings.ToLower(user.GetAttributeValue(a.cluster.GetLDAPUserStatusAttribute())) == strings.ToLower(a.cluster.GetLDAPUserStatusDisabledValue()) {
 			return nil, fmt.Errorf("User account %s is disabled", user.GetAttributeValue(a.cluster.GetLDAPUserIDAttribute()))
 		}
 	}

--- a/pkg/auth/providers/ldap/util.go
+++ b/pkg/auth/providers/ldap/util.go
@@ -13,7 +13,7 @@ func (a *AuthProvider) getUserBase() string {
 
 func (a *AuthProvider) userAttrs() []string {
 	attrs := []string{"cn", "dn", a.cluster.GetLDAPUserIDAttribute(), a.cluster.GetLDAPUserGroupsAttribute()}
-	if !a.cluster.GetLDAPSkipUserStatusCheck() {
+	if a.cluster.GetLDAPDoUserStatusCheck() {
 		attrs = append(attrs, a.cluster.GetLDAPUserStatusAttribute())
 	}
 	return attrs


### PR DESCRIPTION
Removes `insecureSkipStatusCheck` and replaces with `doStatusCheck` which defaults to `false`. 

When set to true, the value of `userStatusAttribute` is checked against `userStatusDisabledValue` to determine if the account has been disabled before trying to bind. 

Would settle #10 